### PR TITLE
V0.11.2 patch 3 (Diff view + description purpose only)

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobBody.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobBody.java
@@ -239,8 +239,19 @@ class RNFetchBlobBody extends RequestBody{
                         is = ctx.getContentResolver().openInputStream(Uri.parse(contentURI));
                         pipeStreamToFileStream(is, os);
                     } catch(Exception e) {
-                        RNFetchBlobUtils.emitWarningEvent(
-                                "Failed to create form data from content URI:" + contentURI + ", " + e.getLocalizedMessage());
+                        try {
+                            if (!contentURI.contains("content://")) {
+                                contentURI = "content://" + contentURI;
+                                is = ctx.getContentResolver().openInputStream(Uri.parse(contentURI));
+                                pipeStreamToFileStream(is, os);
+                            } else {
+                                RNFetchBlobUtils.emitWarningEvent(
+                                        "Failed to create form data from content URI:" + contentURI + ", " + e.getLocalizedMessage());
+                            }
+                        } catch (Exception e1) {
+                            RNFetchBlobUtils.emitWarningEvent(
+                                    "Failed to create form data from content URI:" + contentURI + ", " + e1.getLocalizedMessage());
+                        }
                     } finally {
                         if (is != null) {
                             is.close();

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -657,6 +657,7 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
         String action = intent.getAction();
         if (DownloadManager.ACTION_DOWNLOAD_COMPLETE.equals(action)) {
             Context appCtx = RNFetchBlob.RCTContext.getApplicationContext();
+            appCtx.unregisterReceiver(this);
             long id = intent.getExtras().getLong(DownloadManager.EXTRA_DOWNLOAD_ID);
             if (id == this.downloadManagerId) {
                 releaseTaskResource(); // remove task ID from task map
@@ -673,7 +674,7 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                 }
 
                 String filePath = null;
-                try {    
+                try {
                     // the file exists in media content database
                     if (c.moveToFirst()) {
                         // #297 handle failed request


### PR DESCRIPTION
URI Path should be prefixed with `content://` in order for inputStream to properly find the file. This is a fallback in case it initially can't be found with `content://` prepended in the URI.